### PR TITLE
Parser.ts fix

### DIFF
--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -4,11 +4,12 @@ import { Task } from "./classes"
 export function parsePytestOutput(err: ExecException | null, stdout: string, stderr: string): Task {
     let currTask: Task = new Task()
     
-    if (err === null){
+    if (true) { //orginalnie if(err !== Null), ale wyrażenie zwraca false gdy pystest zwraca failed tests, do poprawienia
         const splitLines: string[] = stdout.split("\n")
         const splitLastLine: string[] = splitLines[splitLines.length - 2].split(",")
 
         for (let i = 0; i < splitLastLine.length; i++) {
+            if (splitLastLine[i][0] === ' ') splitLastLine[i] = splitLastLine[i].substring(1)
             const numAndType: string[] = splitLastLine[i].split(" ")
             switch (numAndType[1]) {
                 case "passed":


### PR DESCRIPTION
- naprawiono splitLastLine()
- dodano tymczasowy if (true), bo orginalny if (err !== Null) nie działał poprawnie - zwraca false gdy pystest zwraca failed tests, do poprawienia